### PR TITLE
Allow to override the name of the header

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,5 @@ Contributors
 Ly Minh Phuong - phuonglm at teracy dot com
 
 Remi Paulmier  - remi.paulmier at gmail dot com
+
+Jacopo Notarstefano - jacopo.notarstefano at gmail dot com

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,12 @@ Usage
 
         $ JWT_AUTH_PREFIX=JWT http --auth-type=jwt --auth="<token>" example.org -h
 
+- Also by default, the ``Authorization`` auth header is used, but you can choose another one:
+
+    ..  code-block:: bash
+
+        $ JWT_AUTH_HEADER=X-Foobar-Authorization http --auth-type=jwt --auth="<token>" example.org -h
+
 - Sometimes you don't need to expose the JWT token on the command line, you can use the environment variable:
 
     ..  code-block:: bash

--- a/httpie_jwt_auth.py
+++ b/httpie_jwt_auth.py
@@ -15,12 +15,13 @@ __license__ = 'BSD'
 class JWTAuth(object):
     """JWTAuth to set the right Authorization header format of JWT"""
 
-    def __init__(self, token, auth_prefix):
+    def __init__(self, token, auth_header, auth_prefix):
         self.token = token
+        self.auth_header = auth_header
         self.auth_prefix = auth_prefix
 
     def __call__(self, request):
-        request.headers['Authorization'] = '{0} {1}'.format(self.auth_prefix, self.token)
+        request.headers[self.auth_header] = '{0} {1}'.format(self.auth_prefix, self.token)
         return request
 
 
@@ -34,10 +35,11 @@ class JWTAuthPlugin(AuthPlugin):
     prompt_password = False
 
     def get_auth(self, username=None, password=None):
+        auth_header = os.environ.get('JWT_AUTH_HEADER', 'Authorization')
         auth_prefix = os.environ.get('JWT_AUTH_PREFIX', 'Bearer')
         env_token = os.environ.get('JWT_AUTH_TOKEN')
         if username is None:
             username = env_token
         if username is None:
             raise Exception('--auth or JWT_AUTH_TOKEN required error')
-        return JWTAuth(username, auth_prefix)
+        return JWTAuth(username, auth_header, auth_prefix)

--- a/tests/integration/test_jwt_auth_plugin.py
+++ b/tests/integration/test_jwt_auth_plugin.py
@@ -117,6 +117,26 @@ def test_specified_env_prefix(httpbin):
     del os.environ['JWT_AUTH_PREFIX']
 
 
+def test_specified_env_header(httpbin):
+    """
+    $ JWT_AUTH_HEADER=X-Foobar-Authorization && http --auth-type=jwt --auth="xyz" [url]
+    => the right X-Foobar-Authorization request header
+    """
+    os.environ['JWT_AUTH_HEADER'] = 'X-Foobar-Authorization'
+    assert os.environ.get('JWT_AUTH_HEADER') == 'X-Foobar-Authorization'
+    r = http(
+        '--auth-type',
+        'jwt',
+        '--auth',
+        'xyz',
+        httpbin.url + '/headers'
+    )
+    assert HTTP_OK in r
+    assert r.json['headers']['X-Foobar-Authorization'] == 'Bearer xyz'
+    # cleanup
+    del os.environ['JWT_AUTH_HEADER']
+
+
 def test_specified_both_env_prefix_and_env_token(httpbin):
     os.environ['JWT_AUTH_PREFIX'] = 'JWT'
     os.environ['JWT_AUTH_TOKEN'] = 'secret'

--- a/tests/unit/test_jwt_auth.py
+++ b/tests/unit/test_jwt_auth.py
@@ -12,9 +12,10 @@ def test_meta_info():
 
 def test_init():
     from httpie_jwt_auth import JWTAuth
-    jwt_auth = JWTAuth('token', 'prefix')
+    jwt_auth = JWTAuth('token', 'header', 'prefix')
 
     assert jwt_auth.token == 'token'
+    assert jwt_auth.auth_header == 'header'
     assert jwt_auth.auth_prefix == 'prefix'
 
 
@@ -25,8 +26,8 @@ def test_call():
             self.headers = headers
 
     request = RequestMock({})
-    jwt_auth = JWTAuth('token', 'prefix')
+    jwt_auth = JWTAuth('token', 'header', 'prefix')
     updated_request = jwt_auth(request)
 
-    assert updated_request.headers['Authorization'] is not None
-    assert updated_request.headers['Authorization'] == 'prefix token'
+    assert updated_request.headers['header'] is not None
+    assert updated_request.headers['header'] == 'prefix token'

--- a/tests/unit/test_jwt_auth_plugin.py
+++ b/tests/unit/test_jwt_auth_plugin.py
@@ -40,6 +40,16 @@ def test_get_auth_prefix():
     del os.environ['JWT_AUTH_PREFIX']
 
 
+def test_get_auth_header():
+    os.environ['JWT_AUTH_HEADER'] = 'X-Foobar-Authorization'
+    jwt_auth_plugin = JWTAuthPlugin()
+    jwt_auth = jwt_auth_plugin.get_auth('token', '')
+
+    assert jwt_auth.token == 'token'
+    assert jwt_auth.auth_header == 'X-Foobar-Authorization'
+    del os.environ['JWT_AUTH_HEADER']
+
+
 def test_get_auth_prefix_and_token():
     os.environ['JWT_AUTH_PREFIX'] = 'JWT'
     os.environ['JWT_AUTH_TOKEN'] = 'secret'


### PR DESCRIPTION
Submitting an early PR without docs or tests (but I swear I will add them!) in order to see if you're interested in this feature: I need to use another header other than `Authorization` for the JWT token. So I added the possibility to override it by setting the `JWT_AUTH_HEADER` environment variable.